### PR TITLE
Fix parsing of `adb shell ps` output

### DIFF
--- a/alogview.go
+++ b/alogview.go
@@ -60,8 +60,8 @@ var (
 )
 
 func init() {
-	// The line pattern is "${user} ${pid} ${ppid} ${vsz} $rss} ${wchan} ${addr} ${s} ${name}"
-	pslineMatcher = regexp.MustCompile(`\w+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\w+\s+[A-Z]\s+(.*)$`)
+	// The line pattern is "${user:w} ${pid:d} ${ppid:d} ${vsz:d} ${rss:d} ${wchan:w} ${addr:w} ${s:w} ${name:w}"
+	pslineMatcher = regexp.MustCompile(`\w+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\w+\s+\w+\s+[A-Z]\s+(.*)$`)
 
 	// The line pattern is "${datetime} ${pid} ${tid} ${level} ${tag}: ${message}"
 	// the datetime is in the format "MM-DD hh:mm:ss.sss"

--- a/alogview.go
+++ b/alogview.go
@@ -119,6 +119,9 @@ func main() {
 			packages[pkg] = true
 		}
 		pids := getProcs(packages)
+		if len(pids) == 0 {
+			warn("no packages found matching the given package(s)")
+		}
 		filters = append(filters, func(line *logLine) bool { return filterByPackages(line, packages, pids) })
 	}
 	printerf := func(line *logLine) { fmt.Printf("%s%s%s\n", colorForLevel(line.level), line.raw, reset) }


### PR DESCRIPTION
The regex to parse the output lines from `adb shell ps` expected the
`WCHAN` field to have a numeric value. This results in an empty list of
PIDs to filter for, which in turn results in no output, since to log
line matches.

Update the regex to expect an alphanumeric value in the `WCHAN` field.

Github: Fixes #4
Signed-off-by: Florian Limberger <flo@snakeoilproductions.net>