### PR TITLE
Fix binary output in file redirection

### DIFF
--- a/alogview.go
+++ b/alogview.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/mattn/go-isatty"
 )
 
 // Custom type for multiple flags
@@ -116,6 +118,7 @@ func main() {
 		adbcmd = adbenv
 	}
 	_, suppresscolor := os.LookupEnv("NO_COLOR")
+	suppresscolor = suppresscolor || !isatty.IsTerminal(os.Stdout.Fd())
 	filters := make([]filter, 0)
 	if len(tags.values) > 0 {
 		filters = append(filters, newTagFilter(tags.values))

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module purplekraken.com/cmd/alogview
+
+go 1.12
+
+require github.com/mattn/go-isatty v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
On terminals, colours are rendered by outputting escape sequences. These
are interpreted as binary when encountered in files, and it is customary
for many command-line utilities to check whether the output goes to a
terminal before inserting those escape sequences into the output. Fis
this issue by adopting that behaviour and checking whether `os.Stdout`
is a TTY. Initialize Go modules to manage the external dependency
`github.com/mattn/go-isatty`.

This introduces the first external dependency, which is a bit sad for me.

Signed-off-by: Florian Limberger <flo@snakeoilproductions.net>
Closes: #8