### PR TITLE
Fix install instruction and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ only log messages emitted by processes belonging to those packages are printed.
 
 `Adb` from the Android SDK is expected to be on the `PATH`.
 
-A simple `go get github.com/flimberger/alogview` is sufficient.
+A simple `go install github.com/flimberger/alogview@main` is sufficient.
+Ensure that `$GOBATH/bin` (defaults to `$HOME/go/bin`) is in our `PATH`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module purplekraken.com/cmd/alogview
+module github.com/flimberger/alogview@main
 
 go 1.17
 


### PR DESCRIPTION
The command from the README.md file does not work. See the output

    $ go get github.com/flimberger/alogview
    go: malformed module path "github.com/flimberger/alogview@main": invalid char '@'

Also `go get` for binaries is deprecated. See

    https://go.dev/doc/go-get-install-deprecation

So rewrite the install instructions to use `go install`. Therefore also the module name must be fixed. Otherwise you get the error:

    go: github.com/flimberger/alogview@latest: version constraints conflict:
            github.com/flimberger/alogview@v0.0.0-20230312104921-95a91a72fdcb: parsing go.mod:
            module declares its path as: purplekraken.com/cmd/alogview
                    but was required as: github.com/flimberger/alogview

So do both. Fix the instructions and the module name. This makes it easier for users to install the tool, because they can just follow the instructions in the README.md file.